### PR TITLE
Stop unsetting user variable EUPS_PKGROOT.

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -6,7 +6,7 @@
 
 
 # clean/backup existing EUPS environment variable
-for var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR EUPS_PKGROOT; do
+for var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR; do
   if [[ "${!var}" ]]; then
     export CONDA_EUPS_BACKUP_${var}="${!var}"
   fi


### PR DESCRIPTION
It is not appropriate for activation to manipulate this variable, as it is a user preference setting, not something that the `eups` package should control.